### PR TITLE
Use public zero-shot model to avoid authentication errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
 
       let classifier = null;
       try {
-        classifier = await pipeline('zero-shot-classification', 'Xenova/nli-roberta-base-v2');
+        classifier = await pipeline('zero-shot-classification', 'Xenova/distilbert-base-uncased-mnli');
       } catch (err) {
         console.error('Failed to load model, falling back to keyword match', err);
       }


### PR DESCRIPTION
## Summary
- replace gated `Xenova/nli-roberta-base-v2` with open `Xenova/distilbert-base-uncased-mnli`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0f5fbbec83228b9c69324d1b245c