### PR TITLE
Adjust generation settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,11 +94,14 @@
         const prompt = `Create an 8x8 pixel art of "${text}".\n` +
           'Respond with JSON {"size":8,"palette":{"1":"#RRGGBB"...},"data":["........"]}';
         const result = await generator(prompt, {
-          max_new_tokens: 400,
+          max_new_tokens: 120,
           return_full_text: false,
-          do_sample: false,
+          do_sample: true,
+          temperature: 0.8,
+          top_p: 0.9,
+          top_k: 50,
         });
-        const raw = result[0].generated_text.trim();
+        const raw = result[0].generated_text.replace(/^[\s\n]+/, '').replace(/[\s\n]+$/, '');
         const match = raw.match(/\{[\s\S]*\}/);
         if (!match) {
           throw new Error("No template returned. Raw output: " + raw);


### PR DESCRIPTION
## Summary
- improve text generation settings to avoid empty output
- strip excessive newlines from model responses

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3082ac04832286fb6d19df145689