### PR TITLE
Improve LLM loading for GPU clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # Repository
 
-이 저장소에는 입력한 텍스트를 기반으로 픽셀 아트를 생성해 주는 간단한 웹 페이지가 포함되어 있습니다. [index.html](./index.html)은 사용자가 입력한 문장을 LLM(Xenova/distilgpt2 모델, [Transformers.js](https://github.com/xenova/transformers.js) 이용)에 전달해 `size`, `palette`, `data` 필드를 가진 JSON 템플릿을 받아오고, 이를 32×32 캔버스에 확대해 표시합니다.
+이 저장소에는 입력한 텍스트를 기반으로 픽셀 아트를 생성해 주는 간단한 웹 페이지가 포함되어 있습니다. [index.html](./index.html)은 사용자가 입력한 문장을 LLM([Transformers.js](https://github.com/xenova/transformers.js) 이용)으로 5단계 분석/생성 파이프라인에 전달하고, `size`, `palette`, `data` 필드를 가진 24×24 픽셀 템플릿을 받아와 렌더링합니다.
 
-`_config.yml` 파일로 기본 블로그 구성을 확인할 수 있습니다.
+## 모델 및 하드웨어 대응
+
+- WebGPU가 감지되면 `onnx-community/TinyLlama-1.1B-Chat-v1.0`(q4) 모델을 우선 시도해 더 긴(약 2K 토큰) 컨텍스트를 제공합니다.
+- WebGPU 로딩에 실패하거나 GPU가 없으면 `onnx-community/ettin-decoder-150m-ONNX` 모델(q4/q8)을 자동으로 사용해 GTX 1050 급 환경에서도 무리 없이 동작하도록 구성되어 있습니다.
+- 프롬프트 길이는 기본적으로 700~1100자 사이로 제한하며, 초과 시 분할 입력을 안내합니다.
+
+## 파일 구성
+
+- `index.html`: 사용자 인터페이스, 모델 로더, 5단계 대화 로직 및 캔버스 렌더링을 포함합니다.
+- `_config.yml`: GitHub Pages용 기본 블로그 설정입니다.
+
+## 실행 방법
+
+브라우저에서 `index.html`을 열면, 텍스트 입력 후 **Generate** 버튼을 통해 5단계 LLM 대화가 실행되고 캔버스에 픽셀 아트 템플릿이 표시됩니다. 로그 영역과 브라우저 콘솔에서 단계별 진행 상황과 토큰 추정치를 확인할 수 있습니다.
 

--- a/index.html
+++ b/index.html
@@ -155,6 +155,46 @@
 
       let hf = null;
       let llm = null;
+      let llmPromise = null;
+      let promptLimit = navigator.gpu ? 1100 : 700;
+
+      const MAX_GPU_PROMPT_CHARS = 1100;
+      const MAX_CPU_PROMPT_CHARS = 700;
+      const MODEL_CHOICES = {
+        webgpu: [
+          {
+            id: 'onnx-community/TinyLlama-1.1B-Chat-v1.0',
+            label: 'TinyLlama 1.1B Chat (q4)',
+            device: 'webgpu',
+            dtype: 'q4',
+            context: '≈2K token context window',
+            promptLimit: MAX_GPU_PROMPT_CHARS,
+            fallbackNotice: 'Falling back to a lighter 150M model to keep memory use low.',
+          },
+          {
+            id: 'onnx-community/ettin-decoder-150m-ONNX',
+            label: 'Ettin Decoder 150M (q4)',
+            device: 'webgpu',
+            dtype: 'q4',
+            context: '≈1K token context window',
+            promptLimit: 850,
+          },
+        ],
+        wasm: [
+          {
+            id: 'onnx-community/ettin-decoder-150m-ONNX',
+            label: 'Ettin Decoder 150M (q8)',
+            device: 'wasm',
+            dtype: 'q8',
+            context: '≈1K token context window',
+            promptLimit: MAX_CPU_PROMPT_CHARS,
+          },
+        ],
+      };
+
+      function estimateTokens(text) {
+        return Math.ceil((text?.length || 0) / 4);
+      }
 
       function setStatus(text) {
         statusEl.textContent = text;
@@ -195,21 +235,64 @@
 
       async function ensureLLM() {
         if (llm) return;
-        setStatus('Loading the model...');
-        hf = await import('https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.7.0');
-        hf.env.allowRemoteModels = true;
-        const device = navigator.gpu ? 'webgpu' : 'wasm';
-        const dtype = navigator.gpu ? 'q4' : 'q8';
-        llm = await hf.pipeline('text-generation', 'onnx-community/ettin-decoder-150m-ONNX', {
-          device,
-          dtype,
-          progress_callback: (progress) => {
-            if (progress?.status && progress?.progress != null) {
-              setStatus(`Model loading ${Math.round(progress.progress * 100)}%`);
+        if (llmPromise) {
+          await llmPromise;
+          return;
+        }
+
+        llmPromise = (async () => {
+          setStatus('Initializing Transformers.js runtime...');
+          if (!hf) {
+            hf = await import('https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.7.0');
+            hf.env.allowRemoteModels = true;
+          }
+
+          const hasWebGPU = Boolean(navigator.gpu);
+          const candidates = [...(MODEL_CHOICES[hasWebGPU ? 'webgpu' : 'wasm'] || [])];
+          const loadErrors = [];
+
+          for (const candidate of candidates) {
+            try {
+              setStatus(`Loading ${candidate.label}...`);
+              const pipeline = await hf.pipeline('text-generation', candidate.id, {
+                device: candidate.device,
+                dtype: candidate.dtype,
+                progress_callback: (progress) => {
+                  if (progress?.status && progress?.progress != null) {
+                    setStatus(`Loading ${candidate.label} ${Math.round(progress.progress * 100)}%`);
+                  }
+                },
+              });
+              llm = pipeline;
+              if (typeof candidate.promptLimit === 'number') {
+                promptLimit = candidate.promptLimit;
+              } else {
+                promptLimit = hasWebGPU ? MAX_GPU_PROMPT_CHARS : MAX_CPU_PROMPT_CHARS;
+              }
+              appendMessage(
+                'assistant',
+                'Model Loader',
+                `Using ${candidate.label} with ${candidate.context}. Keep prompts under ${promptLimit} characters for reliable runs.`,
+              );
+              setStatus(`Model ready. Starting Step 1 dialogue with ${candidate.label}.`);
+              return;
+            } catch (error) {
+              console.warn(`Failed to load ${candidate.id}`, error);
+              loadErrors.push(`${candidate.label}: ${error?.message || 'Unknown error'}`);
+              if (candidate.fallbackNotice) {
+                appendMessage('assistant', 'Model Loader', candidate.fallbackNotice);
+              }
             }
-          },
-        });
-        setStatus('Model ready. Starting Step 1 dialogue.');
+          }
+
+          throw new Error(`Unable to load a supported model. ${loadErrors.join(' | ')}`);
+        })();
+
+        try {
+          await llmPromise;
+        } finally {
+          llmPromise = null;
+        }
       }
 
       function extractJSON(text) {
@@ -248,6 +331,9 @@
 
       async function generateText(prompt, maxTokens, stepLabel) {
         appendMessage('user', `${stepLabel} – Request`, prompt);
+        console.info(
+          `[${stepLabel}] prompt length: ${prompt.length} chars (≈${estimateTokens(prompt)} tokens). max_new_tokens=${maxTokens}`,
+        );
         const out = await llm(prompt, {
           max_new_tokens: maxTokens,
           do_sample: false,
@@ -392,6 +478,14 @@
       async function handleGenerate() {
         const text = promptInput.value.trim();
         if (!text) return;
+        if (text.length > promptLimit) {
+          appendError(
+            'Prompt Too Long',
+            `The request has ${text.length} characters. Please split it into chunks under ${promptLimit} characters to avoid context overflows.`,
+          );
+          setStatus(`Prompt exceeds the ${promptLimit}-character safety budget. Shorten the request and retry.`);
+          return;
+        }
         logEl.innerHTML = '';
         generateBtn.disabled = true;
         setStatus('Preparing the LLM for a five-step dialogue...');
@@ -415,7 +509,19 @@
       });
 
       clearCanvas(24);
-      appendMessage('assistant', 'Guide', 'Enter a prompt and press Generate to launch a five-step English dialogue that produces a pixel-art template.');
+      const hardwareMessage = navigator.gpu
+        ? 'WebGPU detected. The app will try the upgraded TinyLlama 1.1B Chat (q4) model first for a longer context window.'
+        : 'WebGPU unavailable. The app will use the compact Ettin 150M model via WASM for broad compatibility.';
+      appendMessage(
+        'assistant',
+        'System',
+        `${hardwareMessage} Keep each request concise—ideally under ${promptLimit} characters—and split lengthy briefs into sequential runs.`,
+      );
+      appendMessage(
+        'assistant',
+        'Guide',
+        'Enter a prompt and press Generate to launch a five-step English dialogue that produces a pixel-art template. Track progress in the status bar and console token estimates.',
+      );
       promptInput.focus();
     </script>
   </body>


### PR DESCRIPTION
## Summary
- add a hardware-aware loader that prefers the TinyLlama 1.1B Chat q4 WebGPU model and falls back to Ettin 150M when necessary
- enforce prompt length guidance, surface token estimates, and clarify hardware messaging in the UI
- update the README with the new model strategy and usage notes

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ccaf55e10883228cc11cf8a7ace223