### PR TITLE
Sanitize prompt input

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,6 +157,7 @@
       let llm = null;
       let llmPromise = null;
       let promptLimit = navigator.gpu ? 1100 : 700;
+      const SAFE_PROMPT_PATTERN = /[^\p{L}\p{N}\p{Zs}.,!?"'()\-]/gu;
 
       const MAX_GPU_PROMPT_CHARS = 1100;
       const MAX_CPU_PROMPT_CHARS = 700;
@@ -203,8 +204,10 @@
       function sanitizePrompt(text) {
         if (!text) return '';
         return text
+          .normalize('NFC')
           .replace(/[\n\r\t]+/g, ' ')
           .replace(/[\\/][nrt]/gi, ' ')
+          .replace(SAFE_PROMPT_PATTERN, ' ')
           .replace(/\s{2,}/g, ' ')
           .trim();
       }


### PR DESCRIPTION
## Summary
- add a unicode-aware regular expression to filter disallowed special characters from prompts
- normalize and sanitize prompt text to avoid repeated LLM responses caused by control symbols

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccc20d16808322b48295b3b249adfe