### PR TITLE
Enhance procedural fallback pixel templates

### DIFF
--- a/index.html
+++ b/index.html
@@ -1015,6 +1015,11 @@
       }
 
       function buildProceduralTemplate({
+        subject,
+        traits,
+        symbolism,
+        motifs,
+        featurePriority,
         paletteMap,
         accentColor,
         supportColors,
@@ -1065,107 +1070,458 @@
             grid[y][x] = key;
           }
         };
+        const clearPixel = (x, y) => {
+          if (x >= 0 && x < size && y >= 0 && y < size) {
+            grid[y][x] = '0';
+          }
+        };
         const fillSymmetricRow = (y, halfWidth, key) => {
+          const clampY = Math.max(0, Math.min(size - 1, y));
           for (let dx = -halfWidth; dx <= halfWidth; dx += 1) {
-            setPixel(center + dx, y, key);
+            setPixel(center + dx, clampY, key);
+          }
+        };
+        const fillRect = (x0, y0, x1, y1, key) => {
+          const minX = Math.max(0, Math.min(x0, x1));
+          const maxX = Math.min(size - 1, Math.max(x0, x1));
+          const minY = Math.max(0, Math.min(y0, y1));
+          const maxY = Math.min(size - 1, Math.max(y0, y1));
+          for (let y = minY; y <= maxY; y += 1) {
+            for (let x = minX; x <= maxX; x += 1) {
+              setPixel(x, y, key);
+            }
+          }
+        };
+        const drawCircle = (cx, cy, radius, key) => {
+          for (let y = -radius; y <= radius; y += 1) {
+            for (let x = -radius; x <= radius; x += 1) {
+              if (x * x + y * y <= radius * radius + 0.25) {
+                setPixel(cx + x, cy + y, key);
+              }
+            }
           }
         };
 
-        for (let x = center - 6; x <= center + 6; x += 1) {
-          setPixel(x, size - 4, darkKey);
-        }
-        for (let x = center - 5; x <= center + 5; x += 1) {
-          setPixel(x, size - 3, darkKey);
-        }
-
-        for (let y = 6; y <= 16; y += 1) {
-          setPixel(center - 5, y, warmKey);
-          setPixel(center + 5, y, warmKey);
-          if (y % 2 === 0) {
-            setPixel(center - 6, y, warmKey);
-            setPixel(center + 6, y, warmKey);
-          }
-        }
-
-        fillSymmetricRow(4, 1, midKey);
-        setPixel(center, 4, accentKey);
-        fillSymmetricRow(5, 2, midKey);
-        setPixel(center - 1, 5, lightKey);
-        setPixel(center + 1, 5, lightKey);
-
-        fillSymmetricRow(6, 3, midKey);
-        setPixel(center - 3, 6, darkKey);
-        setPixel(center + 3, 6, darkKey);
-        fillSymmetricRow(7, 3, midKey);
-        fillSymmetricRow(8, 3, midKey);
-        fillSymmetricRow(9, 2, midKey);
-        fillSymmetricRow(10, 2, midKey);
-        fillSymmetricRow(11, 2, midKey);
-
-        for (let y = 6; y <= 11; y += 1) {
-          setPixel(center, y, lightKey);
-        }
-        setPixel(center, 7, accentKey);
-
-        fillSymmetricRow(12, 2, midKey);
-        for (let x = center - 2; x <= center + 2; x += 1) {
-          setPixel(x, 12, accentKey);
-        }
-        fillSymmetricRow(13, 2, midKey);
-
-        for (let y = 14; y <= 17; y += 1) {
-          setPixel(center - 1, y, midKey);
-          setPixel(center + 1, y, midKey);
-          setPixel(center - 2, y, darkKey);
-          setPixel(center + 2, y, darkKey);
-        }
-        for (let x = center - 2; x <= center + 2; x += 1) {
-          setPixel(x, 18, darkKey);
-        }
-        setPixel(center - 1, 18, accentKey);
-        setPixel(center + 1, 18, accentKey);
-
-        for (let y = 8; y <= 14; y += 1) {
-          setPixel(center - 5, y, warmKey);
-          if (y >= 9 && y <= 13) {
-            setPixel(center - 6, y, warmKey);
-          }
-        }
-        setPixel(center - 5, 10, lightKey);
-        setPixel(center - 6, 11, accentKey);
-
-        for (let y = 5; y <= 16; y += 1) {
-          setPixel(center + 4, y, lightKey);
-        }
-        setPixel(center + 4, 4, accentKey);
-        setPixel(center + 4, 17, accentKey);
-        setPixel(center + 3, 10, lightKey);
-
-        for (let y = 7; y <= 15; y += 1) {
-          setPixel(center - 3, y, darkKey);
-          setPixel(center + 3, y, darkKey);
-        }
-
-        const detailText = [silhouette, composition, ...(layering || []), ...(keyClusters || []), ...(focalPixels || [])]
+        const detailSegments = [
+          subject,
+          ...(traits || []),
+          ...(symbolism || []),
+          ...(motifs || []),
+          ...(featurePriority || []),
+          silhouette,
+          composition,
+          ...(layering || []),
+          ...(keyClusters || []),
+          ...(focalPixels || []),
+        ];
+        const detailText = detailSegments
+          .filter(Boolean)
           .join(' ')
           .toLowerCase();
-        if (detailText.includes('visor')) {
-          setPixel(center, 5, accentKey);
-          setPixel(center - 1, 5, lightKey);
-          setPixel(center + 1, 5, lightKey);
+        const tokenArray = detailText.match(/[a-z0-9]+/g) || [];
+        const tokenSet = new Set(tokenArray);
+        const hasToken = (...words) => words.some((word) => tokenSet.has(word));
+        const hasAny = (words) => words.some((word) => tokenSet.has(word));
+        const includesPhrase = (phrase) => detailText.includes(phrase);
+
+        const landscapeKeywords = [
+          'landscape',
+          'horizon',
+          'sky',
+          'mountain',
+          'valley',
+          'desert',
+          'forest',
+          'jungle',
+          'river',
+          'ocean',
+          'sea',
+          'coast',
+          'cityscape',
+          'village',
+          'temple',
+          'meadow',
+          'ruins',
+        ];
+        const emblemKeywords = [
+          'emblem',
+          'sigil',
+          'crest',
+          'insignia',
+          'banner',
+          'symbol',
+          'medallion',
+          'icon',
+          'seal',
+        ];
+        const creatureKeywords = [
+          'dragon',
+          'beast',
+          'serpent',
+          'phoenix',
+          'griffin',
+          'wolf',
+          'lion',
+          'animal',
+          'creature',
+          'monster',
+          'bird',
+          'wyvern',
+          'snake',
+          'fish',
+          'whale',
+          'octopus',
+          'spirit',
+        ];
+        const techKeywords = ['robot', 'android', 'cyber', 'mech', 'mecha', 'drone', 'cyborg', 'tech', 'synthetic'];
+
+        let theme = 'character';
+        if (hasAny(landscapeKeywords) || includesPhrase('panorama') || includesPhrase('wide shot')) {
+          theme = 'landscape';
+        } else if (hasAny(emblemKeywords)) {
+          theme = 'emblem';
+        } else if (hasAny(creatureKeywords)) {
+          theme = 'creature';
+        } else if (hasAny(techKeywords)) {
+          theme = 'tech';
         }
-        if (detailText.includes('shield')) {
-          setPixel(center - 6, 10, accentKey);
-          setPixel(center - 5, 12, lightKey);
+        if (subject && /crest|sigil|logo|emblem/i.test(subject)) {
+          theme = 'emblem';
         }
-        if (detailText.includes('sword') || detailText.includes('blade')) {
-          setPixel(center + 4, 3, lightKey);
-          setPixel(center + 4, 2, accentKey);
+        if (!hasAny(landscapeKeywords) && silhouette && /landscape|panorama|horizon/i.test(silhouette)) {
+          theme = 'landscape';
+        }
+
+        const drawHeroicFigure = ({ slender = false, tall = false, dynamicCape = false } = {}) => {
+          const widthAdjust = slender ? -1 : 0;
+          const topShift = tall ? -1 : 0;
+          const applyRow = (y, baseWidth, key) => {
+            const targetY = Math.max(0, Math.min(size - 1, y + topShift));
+            const width = Math.max(0, baseWidth + widthAdjust);
+            fillSymmetricRow(targetY, width, key);
+          };
+
+          for (let x = center - 6; x <= center + 6; x += 1) {
+            setPixel(x, size - 4, darkKey);
+          }
+          for (let x = center - 5; x <= center + 5; x += 1) {
+            setPixel(x, size - 3, darkKey);
+          }
+
+          for (let y = size - 7; y <= size - 4; y += 1) {
+            setPixel(center - 7, y, midKey);
+            setPixel(center + 7, y, midKey);
+          }
+          for (let y = size - 6; y <= size - 5; y += 1) {
+            setPixel(center - 8, y, midKey);
+            setPixel(center + 8, y, midKey);
+          }
+
+          applyRow(4, 1, midKey);
+          setPixel(center, Math.max(0, 4 + topShift), accentKey);
+          applyRow(5, 2, midKey);
+          setPixel(center - 1, Math.max(0, 5 + topShift), lightKey);
+          setPixel(center + 1, Math.max(0, 5 + topShift), lightKey);
+
+          applyRow(6, slender ? 2 : 3, midKey);
+          setPixel(center - 3 + (slender ? 1 : 0), Math.max(0, 6 + topShift), darkKey);
+          setPixel(center + 3 - (slender ? 1 : 0), Math.max(0, 6 + topShift), darkKey);
+          applyRow(7, slender ? 2 : 3, midKey);
+          applyRow(8, slender ? 2 : 3, midKey);
+          applyRow(9, slender ? 1 : 2, midKey);
+          applyRow(10, slender ? 1 : 2, midKey);
+          applyRow(11, slender ? 1 : 2, midKey);
+
+          for (let y = 6; y <= 11; y += 1) {
+            const targetY = Math.max(0, Math.min(size - 1, y + topShift));
+            setPixel(center, targetY, lightKey);
+          }
+          setPixel(center, Math.max(0, 7 + topShift), accentKey);
+
+          applyRow(12, 2, midKey);
+          for (let x = center - 2; x <= center + 2; x += 1) {
+            setPixel(x, Math.max(0, 12 + topShift), accentKey);
+          }
+          applyRow(13, 2, midKey);
+
+          for (let y = 14; y <= 17; y += 1) {
+            const targetY = Math.max(0, Math.min(size - 1, y + topShift));
+            setPixel(center - 1, targetY, midKey);
+            setPixel(center + 1, targetY, midKey);
+            setPixel(center - 2 + (slender ? 1 : 0), targetY, darkKey);
+            setPixel(center + 2 - (slender ? 1 : 0), targetY, darkKey);
+          }
+          for (let x = center - 2 + (slender ? 1 : 0); x <= center + 2 - (slender ? 1 : 0); x += 1) {
+            setPixel(x, Math.max(0, 18 + topShift), darkKey);
+          }
+          setPixel(center - 1, Math.max(0, 18 + topShift), accentKey);
+          setPixel(center + 1, Math.max(0, 18 + topShift), accentKey);
+
+          for (let y = 6; y <= 16; y += 1) {
+            const targetY = Math.max(0, Math.min(size - 1, y + topShift));
+            const offset = slender ? 4 : 5;
+            setPixel(center - offset, targetY, warmKey);
+            setPixel(center + offset, targetY, warmKey);
+            if (!slender && y % 2 === 0) {
+              setPixel(center - offset - 1, targetY, warmKey);
+              setPixel(center + offset + 1, targetY, warmKey);
+            }
+          }
+
+          if (dynamicCape) {
+            for (let y = 9; y <= 17; y += 1) {
+              setPixel(center - 7, Math.max(0, Math.min(size - 1, y + topShift)), warmKey);
+              if (y % 3 === 0) {
+                setPixel(center - 8, Math.max(0, Math.min(size - 1, y + topShift)), warmKey);
+              }
+            }
+          }
+
+          for (let y = 8; y <= 14; y += 1) {
+            const targetY = Math.max(0, Math.min(size - 1, y + topShift));
+            setPixel(center - 5 + (slender ? 1 : 0), targetY, warmKey);
+            if (y >= 9 && y <= 13 && !slender) {
+              setPixel(center - 6, targetY, warmKey);
+            }
+          }
+          setPixel(center - 5 + (slender ? 1 : 0), Math.max(0, 10 + topShift), lightKey);
+          setPixel(center - 6 + (slender ? 1 : 0), Math.max(0, 11 + topShift), accentKey);
+
+          for (let y = 5; y <= 16; y += 1) {
+            const targetY = Math.max(0, Math.min(size - 1, y + topShift));
+            setPixel(center + 4 - (slender ? 1 : 0), targetY, lightKey);
+          }
+          setPixel(center + 4 - (slender ? 1 : 0), Math.max(0, 4 + topShift), accentKey);
+          setPixel(center + 4 - (slender ? 1 : 0), Math.max(0, 17 + topShift), accentKey);
+          setPixel(center + 3 - (slender ? 1 : 0), Math.max(0, 10 + topShift), lightKey);
+
+          for (let y = 7; y <= 15; y += 1) {
+            const targetY = Math.max(0, Math.min(size - 1, y + topShift));
+            setPixel(center - 3 + (slender ? 1 : 0), targetY, darkKey);
+            setPixel(center + 3 - (slender ? 1 : 0), targetY, darkKey);
+          }
+
+          const heroDetailText = detailText;
+          if (heroDetailText.includes('visor')) {
+            setPixel(center, Math.max(0, 5 + topShift), accentKey);
+            setPixel(center - 1, Math.max(0, 5 + topShift), lightKey);
+            setPixel(center + 1, Math.max(0, 5 + topShift), lightKey);
+          }
+          if (heroDetailText.includes('shield')) {
+            setPixel(center - 6 + (slender ? 1 : 0), Math.max(0, 10 + topShift), accentKey);
+            setPixel(center - 5 + (slender ? 1 : 0), Math.max(0, 12 + topShift), lightKey);
+          }
+          if (heroDetailText.includes('sword') || heroDetailText.includes('blade')) {
+            setPixel(center + 4 - (slender ? 1 : 0), Math.max(0, 3 + topShift), lightKey);
+            setPixel(center + 4 - (slender ? 1 : 0), Math.max(0, 2 + topShift), accentKey);
+          }
+          if (heroDetailText.includes('staff') || heroDetailText.includes('wand')) {
+            for (let y = 3; y <= 17; y += 1) {
+              setPixel(center + 6, Math.max(0, Math.min(size - 1, y + topShift)), midKey);
+            }
+            setPixel(center + 6, Math.max(0, 2 + topShift), accentKey);
+          }
+          if (heroDetailText.includes('bow') || heroDetailText.includes('arrow')) {
+            for (let y = 7; y <= 16; y += 1) {
+              setPixel(center - 7, Math.max(0, Math.min(size - 1, y + topShift)), lightKey);
+            }
+            setPixel(center - 6, Math.max(0, 8 + topShift), accentKey);
+          }
+          if (heroDetailText.includes('wing')) {
+            for (let spread = 0; spread <= 5; spread += 1) {
+              const wingY = Math.max(0, Math.min(size - 1, 8 + topShift - Math.floor(spread / 2)));
+              setPixel(center - 8 + spread, wingY, lightKey);
+              setPixel(center + 8 - spread, wingY, lightKey);
+            }
+          }
+          if (heroDetailText.includes('halo') || heroDetailText.includes('aura')) {
+            drawCircle(center, Math.max(0, 3 + topShift), 2, lightKey);
+            setPixel(center, Math.max(0, 2 + topShift), accentKey);
+          }
+          if (slender) {
+            clearPixel(center - 5, Math.max(0, 15 + topShift));
+            clearPixel(center + 5, Math.max(0, 15 + topShift));
+          }
+        };
+
+        const drawTechFigure = () => {
+          drawHeroicFigure({ slender: hasToken('sleek', 'nimble', 'scout'), tall: hasToken('tall', 'towering') });
+          for (let y = 6; y <= 16; y += 2) {
+            setPixel(center - 2, y, accentKey);
+            setPixel(center + 2, y, accentKey);
+          }
+          for (let y = 5; y <= 12; y += 1) {
+            setPixel(center, y, lightKey);
+          }
+          for (let x = center - 4; x <= center + 4; x += 2) {
+            setPixel(x, 9, warmKey);
+          }
+          if (hasToken('jet', 'thruster', 'rocket')) {
+            for (let y = 18; y < size; y += 1) {
+              setPixel(center - 3, y, accentKey);
+              setPixel(center + 3, y, accentKey);
+            }
+          }
+        };
+
+        const drawCreature = () => {
+          const spineY = hasToken('flying', 'sky', 'bird', 'phoenix') ? 9 : 12;
+          for (let x = center - 7; x <= center + 7; x += 1) {
+            const offset = Math.sin(((x - center) / 6) * Math.PI) * (hasToken('serpent', 'snake') ? 2 : 1);
+            setPixel(x, Math.max(0, Math.min(size - 1, spineY + Math.round(offset))), midKey);
+            setPixel(x, Math.max(0, Math.min(size - 1, spineY + Math.round(offset) + 1)), darkKey);
+          }
+          for (let x = center - 6; x <= center + 6; x += 1) {
+            const wingHeight = hasToken('wing', 'phoenix', 'griffin', 'bird')
+              ? Math.max(2, 5 - Math.abs(x - center) / 2)
+              : Math.max(1, 4 - Math.abs(x - center) / 3);
+            for (let y = 0; y < wingHeight; y += 1) {
+              setPixel(x, Math.max(0, spineY - 3 - y), lightKey);
+              if (y === 0) {
+                setPixel(x, Math.max(0, spineY - 4), accentKey);
+              }
+            }
+          }
+          const headX = center + 7;
+          drawCircle(headX, spineY - 1, 2, lightKey);
+          setPixel(headX + 1, spineY - 2, accentKey);
+          setPixel(headX + 1, spineY, accentKey);
+          if (hasToken('fire', 'ember', 'flame')) {
+            for (let i = 0; i < 4; i += 1) {
+              setPixel(headX + 2 + i, spineY - 2 + (i % 2), warmKey);
+            }
+          }
+          if (hasToken('ice', 'frost', 'snow')) {
+            for (let i = 0; i < 4; i += 1) {
+              setPixel(center - 8 + i, spineY + 3, lightKey);
+            }
+          }
+          if (hasToken('tail', 'serpent', 'dragon')) {
+            for (let i = 0; i < 6; i += 1) {
+              setPixel(center - 8 - i, spineY + 1 + Math.floor(i / 2), darkKey);
+              if (i % 2 === 0) {
+                setPixel(center - 8 - i, spineY + Math.floor(i / 2), accentKey);
+              }
+            }
+          }
+        };
+
+        const drawLandscape = () => {
+          const horizon = includesPhrase('low angle') ? size - 8 : includesPhrase('overhead') ? 9 : 12;
+          for (let y = horizon; y < size; y += 1) {
+            const key = y === horizon ? midKey : y >= size - 3 ? darkKey : midKey;
+            for (let x = 0; x < size; x += 1) {
+              setPixel(x, y, key);
+            }
+          }
+          for (let y = 0; y < horizon; y += 1) {
+            const blend = y / Math.max(1, horizon - 1);
+            const key = blend < 0.4 ? lightKey : blend < 0.8 ? midKey : warmKey;
+            for (let x = 0; x < size; x += 1) {
+              if (grid[y][x] === '0') {
+                setPixel(x, y, key);
+              }
+            }
+          }
+          if (hasToken('sun', 'sunset', 'dawn')) {
+            drawCircle(center - 6, Math.max(3, horizon - 6), 3, accentKey);
+          } else if (hasToken('moon', 'night', 'stars')) {
+            drawCircle(center + 7, Math.max(2, horizon - 7), 2, lightKey);
+            for (let i = 0; i < 20; i += 1) {
+              const starX = (i * 5 + 3) % size;
+              const starY = Math.floor((i * 7) % Math.max(2, horizon - 2));
+              setPixel(starX, starY, accentKey);
+            }
+          }
+          if (hasToken('mountain', 'peak')) {
+            for (let x = 2; x < size - 2; x += 1) {
+              const dist = Math.abs(x - center);
+              const height = Math.max(0, 6 - Math.floor(dist / 2));
+              for (let y = 0; y < height; y += 1) {
+                const targetY = horizon - 1 - y;
+                setPixel(x, targetY, darkKey);
+                if (y === height - 1) {
+                  setPixel(x, targetY, lightKey);
+                }
+              }
+            }
+          }
+          if (hasToken('forest', 'trees', 'jungle')) {
+            for (let x = 0; x < size; x += 3) {
+              for (let y = horizon - 1; y < size - 1; y += 1) {
+                setPixel(x, y, darkKey);
+              }
+              setPixel(x, horizon - 2, warmKey);
+            }
+          }
+          if (hasToken('river', 'lake', 'water', 'sea', 'ocean')) {
+            const waterY = horizon + 2;
+            for (let x = 0; x < size; x += 1) {
+              setPixel(x, waterY, lightKey);
+              if (x % 3 === 0) {
+                setPixel(x, waterY + 1, accentKey);
+              }
+            }
+          }
+          if (hasToken('city', 'village', 'temple', 'castle', 'ruins')) {
+            for (let block = 0; block < 5; block += 1) {
+              const blockX = 2 + block * 4;
+              const blockHeight = 2 + (block % 3);
+              fillRect(blockX, horizon - blockHeight, blockX + 2, horizon - 1, darkKey);
+              setPixel(blockX + 1, horizon - blockHeight, accentKey);
+            }
+          }
+        };
+
+        const drawEmblem = () => {
+          drawCircle(center, 12, 8, midKey);
+          drawCircle(center, 12, 6, lightKey);
+          drawCircle(center, 12, 4, warmKey);
+          drawCircle(center, 12, 2, accentKey);
+          for (let angle = 0; angle < 360; angle += 45) {
+            const rad = (angle * Math.PI) / 180;
+            const x = center + Math.round(Math.cos(rad) * 8);
+            const y = 12 + Math.round(Math.sin(rad) * 8);
+            setPixel(x, y, darkKey);
+          }
+          if (hasToken('star')) {
+            for (let i = -2; i <= 2; i += 1) {
+              setPixel(center + i, 12, accentKey);
+              setPixel(center, 12 + i, accentKey);
+            }
+          } else if (hasToken('phoenix', 'dragon', 'lion', 'wolf')) {
+            for (let i = -3; i <= 3; i += 1) {
+              setPixel(center + i, 9 + Math.abs(i), darkKey);
+              if (Math.abs(i) === 3) {
+                setPixel(center + i, 9 + Math.abs(i) - 1, accentKey);
+              }
+            }
+          }
+          if (hasToken('banner', 'ribbon')) {
+            fillRect(center - 9, 5, center + 9, 7, warmKey);
+          }
+        };
+
+        if (theme === 'landscape') {
+          drawLandscape();
+        } else if (theme === 'emblem') {
+          drawEmblem();
+        } else if (theme === 'creature') {
+          drawCreature();
+        } else if (theme === 'tech') {
+          drawTechFigure();
+        } else {
+          drawHeroicFigure({
+            slender: hasToken('mage', 'wizard', 'witch', 'priest', 'archer', 'assassin', 'dancer'),
+            tall: hasToken('tall', 'towering', 'giant', 'guardian') || includesPhrase('vertical'),
+            dynamicCape: hasToken('cape', 'cloak', 'mantle', 'cloak'),
+          });
         }
 
         const data = grid.map((row) => row.join(''));
         return { size, palette, data };
       }
+
 
       async function generateText(prompt, maxTokens, stepLabel, overrides = {}) {
         appendMessage('user', `${stepLabel} – Request`, prompt);
@@ -1400,6 +1756,11 @@
             `${templatePlan?.reason || 'Template validation failed.'} Using a procedural fallback to complete the pixel grid.`,
           );
           const fallbackTemplate = buildProceduralTemplate({
+            subject,
+            traits,
+            symbolism,
+            motifs,
+            featurePriority,
             paletteMap,
             accentColor: accent,
             supportColors,


### PR DESCRIPTION
## Summary
- expand the procedural fallback to analyze the subject, traits, symbolism, and motifs before drawing
- add theme-specific renderers for characters, creatures, landscapes, emblems, and tech silhouettes using the derived cues
- feed the richer planning context into the fallback builder when Step 5 JSON fails, ensuring varied pixel layouts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6260a86d483228d51a1d58c17c79a